### PR TITLE
DOC: separate olog user env var from system var $USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ from olog import Client
 import os
 
 cli = Client(os.eniron['OLOG_URL'],
-             os.environ['USER'],
-             os.environ['PASSWORD'])
+             os.environ['OLOG_USER'],
+             os.environ['OLOG_PASSWORD'])
 ```
 
 Use the methods on the Client. For example:


### PR DESCRIPTION
I think it's worth to separate olog user and env variable `$USER`, which do not have to match. So, I'm suggesting to have `OLOG_USER` and `OLOG_PASSWORD` to avoid ambiguity.
